### PR TITLE
Add datasets_wikidata.csv

### DIFF
--- a/data/datasets_wikidata.csv
+++ b/data/datasets_wikidata.csv
@@ -1,77 +1,77 @@
 query,params,expected
-Base de données publique des médicaments,NA,53698f50a3a729239d2036f5
-BDM,NA,53698f50a3a729239d2036f5
-BdM,NA,53698f50a3a729239d2036f5
-BDPM,NA,53698f50a3a729239d2036f5
-Autorités BnF,NA,53699211a3a729239d203e0e
-Autorité BnF,NA,53699211a3a729239d203e0e
-Bnf autorités,NA,53699211a3a729239d203e0e
-data.bnf.fr,NA,53699211a3a729239d203e0e
-Entrepôt d’indicateurs et de données sur l'environnement,NA,5369945ba3a729239d204413
-EIDER,NA,5369945ba3a729239d204413
-Fichier national des établissements sanitaires et sociaux,NA,53699569a3a729239d2046eb
-FINESS,NA,53699569a3a729239d2046eb
-répertoire FINESS,NA,53699569a3a729239d2046eb
-FANTOIR,NA,53699580a3a729239d204738
-Fichier ANnuaire TOpographique Initialisé Réduit,NA,53699580a3a729239d204738
-Répertoire Informatisé des VOies et LIeux-dits,NA,53699580a3a729239d204738
-RIVOLI,NA,53699580a3a729239d204738
-Open Food Facts,NA,53699e2aa3a729239d205dea
-OFF,NA,53699e2aa3a729239d205dea
-OpenFoodFacts,NA,53699e2aa3a729239d205dea
-openfoodfacts.org,NA,53699e2aa3a729239d205dea
-Table de composition nutritionnelle des aliments Ciqual,NA,5369a15fa3a729239d2065b7
-base de données CIQUAL,NA,5369a15fa3a729239d2065b7
-Ciqual,NA,5369a15fa3a729239d2065b7
-Table Ciqual,NA,5369a15fa3a729239d2065b7
-Base Adresse Nationale,NA,5530fbacc751df5ff937dddb
-BAN,NA,5530fbacc751df5ff937dddb
-base adresse nationale,NA,5530fbacc751df5ff937dddb
-Transparence-Santé,NA,5710b9f088ee383cf54d8898
-Transparence Santé,NA,5710b9f088ee383cf54d8898
-Fichier des prénoms,NA,586a824588ee3835ec3f4e61
-base Mérimée,NA,5890bf73a3a72974c1f0dc84
-Mérimée,NA,5890bf73a3a72974c1f0dc84
-Code officiel géographique,NA,58c984b088ee386cdb1261f3
-COG,NA,58c984b088ee386cdb1261f3
-Registre parcellaire graphique,NA,58d8d8a0c751df17537c66be
-RPG,NA,58d8d8a0c751df17537c66be
-Répertoire opérationnel des métiers et des emplois,NA,58da857388ee384902e505f5
-Code ROME,NA,58da857388ee384902e505f5
-Repertoire operationnel des metiers et des emplois,NA,58da857388ee384902e505f5
-Répertoire Opérationnel des Métiers et des Emplois,NA,58da857388ee384902e505f5
-ROME,NA,58da857388ee384902e505f5
-Rome (répertoire),NA,58da857388ee384902e505f5
-Répertoire national des associations,NA,58e53811c751df03df38f42d
-RNA,NA,58e53811c751df03df38f42d
-Répertoire National des Associations,NA,58e53811c751df03df38f42d
-Référentiel à grande échelle,NA,58e5842688ee386c65805755
-RGE,NA,58e5842688ee386c65805755
-référentiel géographique à grande échelle,NA,58e5842688ee386c65805755
-Open Beauty Facts,NA,5985d205c751df6d505e7e86
-Répertoire des logements locatifs des bailleurs sociaux,NA,5a1dd4e5c751df02b116a0d6
-RPLS,NA,5a1dd4e5c751df02b116a0d6
-Compte général de l'État,NA,5b08106e88ee383d19158fb6
-Joconde,NA,5b448216a3a729752eb11d6f
-Base Joconde,NA,5b448216a3a729752eb11d6f
-base Joconde,NA,5b448216a3a729752eb11d6f
-catalogue Joconde,NA,5b448216a3a729752eb11d6f
-système national d'identification et du répertoire des entreprises et de leurs établissements,NA,5b7ffc618b4c4169d30727e0
-base SIRENE,NA,5b7ffc618b4c4169d30727e0
-SIRENE,NA,5b7ffc618b4c4169d30727e0
-Système informatisé du répertoire national des entreprises et des établissements,NA,5b7ffc618b4c4169d30727e0
-Musée d'art et d'histoire de Saint-Brieuc - historique des expositions,NA,5bae279c8b4c410765b5eb4e
-Fichier des prénoms,NA,5bf42c958b4c4144b0110ce8
-Répertoire national des élus,NA,5c34c4d1634f4173183a64f1
-RNE,NA,5c34c4d1634f4173183a64f1
-Demande de valeurs foncières,NA,5c4ae55a634f4117716d5656
-base DVF,NA,5c4ae55a634f4117716d5656
-DVF,NA,5c4ae55a634f4117716d5656
-fichier des personnes décédées,NA,5de8f397634f4164071119c5
-Fichier des décès,NA,5de8f397634f4164071119c5
-FPD,NA,5de8f397634f4164071119c5
-INSEE Décès,NA,5de8f397634f4164071119c5
-matchID - Fichier des décès,NA,5de8f397634f4164071119c5
-Base nationale sur l'intercommunalité,NA,5e1f20058b4c414d3f94460d
-BANATIC,NA,5e1f20058b4c414d3f94460d
-Agribalyse,NA,5f71f6b9f23df7fcd508af57
+Base de données publique des médicaments,,53698f50a3a729239d2036f5
+BDM,,53698f50a3a729239d2036f5
+BdM,,53698f50a3a729239d2036f5
+BDPM,,53698f50a3a729239d2036f5
+Autorités BnF,,53699211a3a729239d203e0e
+Autorité BnF,,53699211a3a729239d203e0e
+Bnf autorités,,53699211a3a729239d203e0e
+data.bnf.fr,,53699211a3a729239d203e0e
+Entrepôt d’indicateurs et de données sur l'environnement,,5369945ba3a729239d204413
+EIDER,,5369945ba3a729239d204413
+Fichier national des établissements sanitaires et sociaux,,53699569a3a729239d2046eb
+FINESS,,53699569a3a729239d2046eb
+répertoire FINESS,,53699569a3a729239d2046eb
+FANTOIR,,53699580a3a729239d204738
+Fichier ANnuaire TOpographique Initialisé Réduit,,53699580a3a729239d204738
+Répertoire Informatisé des VOies et LIeux-dits,,53699580a3a729239d204738
+RIVOLI,,53699580a3a729239d204738
+Open Food Facts,,53699e2aa3a729239d205dea
+OFF,,53699e2aa3a729239d205dea
+OpenFoodFacts,,53699e2aa3a729239d205dea
+openfoodfacts.org,,53699e2aa3a729239d205dea
+Table de composition nutritionnelle des aliments Ciqual,,5369a15fa3a729239d2065b7
+base de données CIQUAL,,5369a15fa3a729239d2065b7
+Ciqual,,5369a15fa3a729239d2065b7
+Table Ciqual,,5369a15fa3a729239d2065b7
+Base Adresse Nationale,,5530fbacc751df5ff937dddb
+BAN,,5530fbacc751df5ff937dddb
+base adresse nationale,,5530fbacc751df5ff937dddb
+Transparence-Santé,,5710b9f088ee383cf54d8898
+Transparence Santé,,5710b9f088ee383cf54d8898
+Fichier des prénoms,,586a824588ee3835ec3f4e61
+base Mérimée,,5890bf73a3a72974c1f0dc84
+Mérimée,,5890bf73a3a72974c1f0dc84
+Code officiel géographique,,58c984b088ee386cdb1261f3
+COG,,58c984b088ee386cdb1261f3
+Registre parcellaire graphique,,58d8d8a0c751df17537c66be
+RPG,,58d8d8a0c751df17537c66be
+Répertoire opérationnel des métiers et des emplois,,58da857388ee384902e505f5
+Code ROME,,58da857388ee384902e505f5
+Repertoire operationnel des metiers et des emplois,,58da857388ee384902e505f5
+Répertoire Opérationnel des Métiers et des Emplois,,58da857388ee384902e505f5
+ROME,,58da857388ee384902e505f5
+Rome (répertoire),,58da857388ee384902e505f5
+Répertoire national des associations,,58e53811c751df03df38f42d
+RNA,,58e53811c751df03df38f42d
+Répertoire National des Associations,,58e53811c751df03df38f42d
+Référentiel à grande échelle,,58e5842688ee386c65805755
+RGE,,58e5842688ee386c65805755
+référentiel géographique à grande échelle,,58e5842688ee386c65805755
+Open Beauty Facts,,5985d205c751df6d505e7e86
+Répertoire des logements locatifs des bailleurs sociaux,,5a1dd4e5c751df02b116a0d6
+RPLS,,5a1dd4e5c751df02b116a0d6
+Compte général de l'État,,5b08106e88ee383d19158fb6
+Joconde,,5b448216a3a729752eb11d6f
+Base Joconde,,5b448216a3a729752eb11d6f
+base Joconde,,5b448216a3a729752eb11d6f
+catalogue Joconde,,5b448216a3a729752eb11d6f
+système national d'identification et du répertoire des entreprises et de leurs établissements,,5b7ffc618b4c4169d30727e0
+base SIRENE,,5b7ffc618b4c4169d30727e0
+SIRENE,,5b7ffc618b4c4169d30727e0
+Système informatisé du répertoire national des entreprises et des établissements,,5b7ffc618b4c4169d30727e0
+Musée d'art et d'histoire de Saint-Brieuc - historique des expositions,,5bae279c8b4c410765b5eb4e
+Fichier des prénoms,,5bf42c958b4c4144b0110ce8
+Répertoire national des élus,,5c34c4d1634f4173183a64f1
+RNE,,5c34c4d1634f4173183a64f1
+Demande de valeurs foncières,,5c4ae55a634f4117716d5656
+base DVF,,5c4ae55a634f4117716d5656
+DVF,,5c4ae55a634f4117716d5656
+fichier des personnes décédées,,5de8f397634f4164071119c5
+Fichier des décès,,5de8f397634f4164071119c5
+FPD,,5de8f397634f4164071119c5
+INSEE Décès,,5de8f397634f4164071119c5
+matchID - Fichier des décès,,5de8f397634f4164071119c5
+Base nationale sur l'intercommunalité,,5e1f20058b4c414d3f94460d
+BANATIC,,5e1f20058b4c414d3f94460d
+Agribalyse,,5f71f6b9f23df7fcd508af57

--- a/data/datasets_wikidata.csv
+++ b/data/datasets_wikidata.csv
@@ -1,0 +1,122 @@
+query,params,expected
+Base de données publique des médicaments,NA,53698f50a3a729239d2036f5
+BDM,NA,53698f50a3a729239d2036f5
+BdM,NA,53698f50a3a729239d2036f5
+BDPM,NA,53698f50a3a729239d2036f5
+formations pas de calais,NA,53699058a3a729239d2039a3
+contours départements,NA,536991b0a3a729239d203d13
+contours départements français,NA,536991b0a3a729239d203d13
+Autorités BnF,NA,53699211a3a729239d203e0e
+Autorité BnF,NA,53699211a3a729239d203e0e
+Bnf autorités,NA,53699211a3a729239d203e0e
+data.bnf.fr,NA,53699211a3a729239d203e0e
+contour commune,NA,53699233a3a729239d203e69
+contours communes,NA,53699233a3a729239d203e69
+contour communes,NA,53699233a3a729239d203e69
+Entrepôt d’indicateurs et de données sur l'environnement,NA,5369945ba3a729239d204413
+EIDER,NA,5369945ba3a729239d204413
+Fichier national des établissements sanitaires et sociaux,NA,53699569a3a729239d2046eb
+FINESS,NA,53699569a3a729239d2046eb
+répertoire FINESS,NA,53699569a3a729239d2046eb
+FANTOIR,NA,53699580a3a729239d204738
+Fichier ANnuaire TOpographique Initialisé Réduit,NA,53699580a3a729239d204738
+Répertoire Informatisé des VOies et LIeux-dits,NA,53699580a3a729239d204738
+RIVOLI,NA,53699580a3a729239d204738
+géofla départements,NA,536995f5a3a729239d20487f
+accidents de la circulation,NA,536997eaa3a729239d204dfd
+accidents de la route,NA,536997eaa3a729239d204dfd
+effectifs police municipale,NA,5369986ba3a729239d204f55
+Open Food Facts,NA,53699e2aa3a729239d205dea
+OFF,NA,53699e2aa3a729239d205dea
+OpenFoodFacts,NA,53699e2aa3a729239d205dea
+openfoodfacts.org,NA,53699e2aa3a729239d205dea
+vie-publique répertoire,NA,53699f06a3a729239d20601c
+Table de composition nutritionnelle des aliments Ciqual,NA,5369a15fa3a729239d2065b7
+base de données CIQUAL,NA,5369a15fa3a729239d2065b7
+Ciqual,NA,5369a15fa3a729239d2065b7
+Table Ciqual,NA,5369a15fa3a729239d2065b7
+emissions polluantes,NA,53ba4c07a3a729219b7bead3
+code postal,NA,545b55e1c751df52de9b6045
+codes postaux,NA,545b55e1c751df52de9b6045
+open damir,NA,54de1e8fc751df388646738b
+opendamir,NA,54de1e8fc751df388646738b
+damir,NA,54de1e8fc751df388646738b
+Base Adresse Nationale,NA,5530fbacc751df5ff937dddb
+BAN,NA,5530fbacc751df5ff937dddb
+base adresse nationale,NA,5530fbacc751df5ff937dddb
+loi de finance 2016,NA,5625fba688ee3820e912613c
+lolf 2016,NA,5625fba688ee3820e912613c
+risque de décès un an après accident,NA,5630f53b88ee385064531578
+Transparence-Santé,NA,5710b9f088ee383cf54d8898
+Transparence Santé,NA,5710b9f088ee383cf54d8898
+organismes de formation,NA,582c8978c751df788ec0bb7e
+organisme de formation,NA,582c8978c751df788ec0bb7e
+Fichier des prénoms,NA,586a824588ee3835ec3f4e61
+annuaire de l'éducation,NA,5889d03fa3a72974cbf0d5b1
+base Mérimée,NA,5890bf73a3a72974c1f0dc84
+Mérimée,NA,5890bf73a3a72974c1f0dc84
+COG,NA,58c984b088ee386cdb1261f3
+code officiel géographique,NA,58c984b088ee386cdb1261f3
+Code officiel géographique,NA,58c984b088ee386cdb1261f3
+Registre parcellaire graphique,NA,58d8d8a0c751df17537c66be
+RPG,NA,58d8d8a0c751df17537c66be
+Répertoire opérationnel des métiers et des emplois,NA,58da857388ee384902e505f5
+Code ROME,NA,58da857388ee384902e505f5
+Repertoire operationnel des metiers et des emplois,NA,58da857388ee384902e505f5
+Répertoire Opérationnel des Métiers et des Emplois,NA,58da857388ee384902e505f5
+ROME,NA,58da857388ee384902e505f5
+Rome (répertoire),NA,58da857388ee384902e505f5
+association,NA,58e53811c751df03df38f42d
+associations,NA,58e53811c751df03df38f42d
+RNA,NA,58e53811c751df03df38f42d
+NA,tag=association,58e53811c751df03df38f42d
+répertoire des associations,NA,58e53811c751df03df38f42d
+répertoire national des associations,NA,58e53811c751df03df38f42d
+waldec,NA,58e53811c751df03df38f42d
+Répertoire national des associations,NA,58e53811c751df03df38f42d
+Répertoire National des Associations,NA,58e53811c751df03df38f42d
+Référentiel à grande échelle,NA,58e5842688ee386c65805755
+RGE,NA,58e5842688ee386c65805755
+référentiel géographique à grande échelle,NA,58e5842688ee386c65805755
+Liste gares SNCF,NA,59593619a3a7291dd09c8238
+Open Beauty Facts,NA,5985d205c751df6d505e7e86
+marchés public bourgogne,NA,5a0effeac751df5832ded865
+Répertoire des logements locatifs des bailleurs sociaux,NA,5a1dd4e5c751df02b116a0d6
+RPLS,NA,5a1dd4e5c751df02b116a0d6
+bibliothèques,NA,5a4e847cb59508409d014056
+Compte général de l'État,NA,5b08106e88ee383d19158fb6
+Joconde,NA,5b448216a3a729752eb11d6f
+Base Joconde,NA,5b448216a3a729752eb11d6f
+base Joconde,NA,5b448216a3a729752eb11d6f
+catalogue Joconde,NA,5b448216a3a729752eb11d6f
+siren,NA,5b7ffc618b4c4169d30727e0
+sirene,NA,5b7ffc618b4c4169d30727e0
+entreprise,NA,5b7ffc618b4c4169d30727e0
+entreprises,NA,5b7ffc618b4c4169d30727e0
+siret,NA,5b7ffc618b4c4169d30727e0
+système national d'identification et du répertoire des entreprises et de leurs établissements,NA,5b7ffc618b4c4169d30727e0
+base SIRENE,NA,5b7ffc618b4c4169d30727e0
+SIRENE,NA,5b7ffc618b4c4169d30727e0
+Système informatisé du répertoire national des entreprises et des établissements,NA,5b7ffc618b4c4169d30727e0
+Musée d'art et d'histoire de Saint-Brieuc - historique des expositions,NA,5bae279c8b4c410765b5eb4e
+prénoms,NA,5bf42c958b4c4144b0110ce8
+Fichier des prénoms,NA,5bf42c958b4c4144b0110ce8
+élus,NA,5c34c4d1634f4173183a64f1
+RNE,NA,5c34c4d1634f4173183a64f1
+répertoire des élus,NA,5c34c4d1634f4173183a64f1
+repertoire des elus,NA,5c34c4d1634f4173183a64f1
+Répertoire national des élus,NA,5c34c4d1634f4173183a64f1
+Demande de valeurs foncières,NA,5c4ae55a634f4117716d5656
+base DVF,NA,5c4ae55a634f4117716d5656
+DVF,NA,5c4ae55a634f4117716d5656
+grand débat,NA,5c5c3236634f4155110aa4ea
+fichier des personnes décédées,NA,5de8f397634f4164071119c5
+Fichier des décès,NA,5de8f397634f4164071119c5
+FPD,NA,5de8f397634f4164071119c5
+INSEE Décès,NA,5de8f397634f4164071119c5
+matchID - Fichier des décès,NA,5de8f397634f4164071119c5
+Base nationale sur l'intercommunalité,NA,5e1f20058b4c414d3f94460d
+BANATIC,NA,5e1f20058b4c414d3f94460d
+Agribalyse,NA,5f71f6b9f23df7fcd508af57
+ovq,NA,5ff5e6e99724cb8fff59a5be
+baromètre des résultats,NA,5ff5e6e99724cb8fff59a5be

--- a/data/datasets_wikidata.csv
+++ b/data/datasets_wikidata.csv
@@ -3,16 +3,10 @@ Base de données publique des médicaments,NA,53698f50a3a729239d2036f5
 BDM,NA,53698f50a3a729239d2036f5
 BdM,NA,53698f50a3a729239d2036f5
 BDPM,NA,53698f50a3a729239d2036f5
-formations pas de calais,NA,53699058a3a729239d2039a3
-contours départements,NA,536991b0a3a729239d203d13
-contours départements français,NA,536991b0a3a729239d203d13
 Autorités BnF,NA,53699211a3a729239d203e0e
 Autorité BnF,NA,53699211a3a729239d203e0e
 Bnf autorités,NA,53699211a3a729239d203e0e
 data.bnf.fr,NA,53699211a3a729239d203e0e
-contour commune,NA,53699233a3a729239d203e69
-contours communes,NA,53699233a3a729239d203e69
-contour communes,NA,53699233a3a729239d203e69
 Entrepôt d’indicateurs et de données sur l'environnement,NA,5369945ba3a729239d204413
 EIDER,NA,5369945ba3a729239d204413
 Fichier national des établissements sanitaires et sociaux,NA,53699569a3a729239d2046eb
@@ -22,42 +16,24 @@ FANTOIR,NA,53699580a3a729239d204738
 Fichier ANnuaire TOpographique Initialisé Réduit,NA,53699580a3a729239d204738
 Répertoire Informatisé des VOies et LIeux-dits,NA,53699580a3a729239d204738
 RIVOLI,NA,53699580a3a729239d204738
-géofla départements,NA,536995f5a3a729239d20487f
-accidents de la circulation,NA,536997eaa3a729239d204dfd
-accidents de la route,NA,536997eaa3a729239d204dfd
-effectifs police municipale,NA,5369986ba3a729239d204f55
 Open Food Facts,NA,53699e2aa3a729239d205dea
 OFF,NA,53699e2aa3a729239d205dea
 OpenFoodFacts,NA,53699e2aa3a729239d205dea
 openfoodfacts.org,NA,53699e2aa3a729239d205dea
-vie-publique répertoire,NA,53699f06a3a729239d20601c
 Table de composition nutritionnelle des aliments Ciqual,NA,5369a15fa3a729239d2065b7
 base de données CIQUAL,NA,5369a15fa3a729239d2065b7
 Ciqual,NA,5369a15fa3a729239d2065b7
 Table Ciqual,NA,5369a15fa3a729239d2065b7
-emissions polluantes,NA,53ba4c07a3a729219b7bead3
-code postal,NA,545b55e1c751df52de9b6045
-codes postaux,NA,545b55e1c751df52de9b6045
-open damir,NA,54de1e8fc751df388646738b
-opendamir,NA,54de1e8fc751df388646738b
-damir,NA,54de1e8fc751df388646738b
 Base Adresse Nationale,NA,5530fbacc751df5ff937dddb
 BAN,NA,5530fbacc751df5ff937dddb
 base adresse nationale,NA,5530fbacc751df5ff937dddb
-loi de finance 2016,NA,5625fba688ee3820e912613c
-lolf 2016,NA,5625fba688ee3820e912613c
-risque de décès un an après accident,NA,5630f53b88ee385064531578
 Transparence-Santé,NA,5710b9f088ee383cf54d8898
 Transparence Santé,NA,5710b9f088ee383cf54d8898
-organismes de formation,NA,582c8978c751df788ec0bb7e
-organisme de formation,NA,582c8978c751df788ec0bb7e
 Fichier des prénoms,NA,586a824588ee3835ec3f4e61
-annuaire de l'éducation,NA,5889d03fa3a72974cbf0d5b1
 base Mérimée,NA,5890bf73a3a72974c1f0dc84
 Mérimée,NA,5890bf73a3a72974c1f0dc84
-COG,NA,58c984b088ee386cdb1261f3
-code officiel géographique,NA,58c984b088ee386cdb1261f3
 Code officiel géographique,NA,58c984b088ee386cdb1261f3
+COG,NA,58c984b088ee386cdb1261f3
 Registre parcellaire graphique,NA,58d8d8a0c751df17537c66be
 RPG,NA,58d8d8a0c751df17537c66be
 Répertoire opérationnel des métiers et des emplois,NA,58da857388ee384902e505f5
@@ -66,50 +42,31 @@ Repertoire operationnel des metiers et des emplois,NA,58da857388ee384902e505f5
 Répertoire Opérationnel des Métiers et des Emplois,NA,58da857388ee384902e505f5
 ROME,NA,58da857388ee384902e505f5
 Rome (répertoire),NA,58da857388ee384902e505f5
-association,NA,58e53811c751df03df38f42d
-associations,NA,58e53811c751df03df38f42d
-RNA,NA,58e53811c751df03df38f42d
-NA,tag=association,58e53811c751df03df38f42d
-répertoire des associations,NA,58e53811c751df03df38f42d
-répertoire national des associations,NA,58e53811c751df03df38f42d
-waldec,NA,58e53811c751df03df38f42d
 Répertoire national des associations,NA,58e53811c751df03df38f42d
+RNA,NA,58e53811c751df03df38f42d
 Répertoire National des Associations,NA,58e53811c751df03df38f42d
 Référentiel à grande échelle,NA,58e5842688ee386c65805755
 RGE,NA,58e5842688ee386c65805755
 référentiel géographique à grande échelle,NA,58e5842688ee386c65805755
-Liste gares SNCF,NA,59593619a3a7291dd09c8238
 Open Beauty Facts,NA,5985d205c751df6d505e7e86
-marchés public bourgogne,NA,5a0effeac751df5832ded865
 Répertoire des logements locatifs des bailleurs sociaux,NA,5a1dd4e5c751df02b116a0d6
 RPLS,NA,5a1dd4e5c751df02b116a0d6
-bibliothèques,NA,5a4e847cb59508409d014056
 Compte général de l'État,NA,5b08106e88ee383d19158fb6
 Joconde,NA,5b448216a3a729752eb11d6f
 Base Joconde,NA,5b448216a3a729752eb11d6f
 base Joconde,NA,5b448216a3a729752eb11d6f
 catalogue Joconde,NA,5b448216a3a729752eb11d6f
-siren,NA,5b7ffc618b4c4169d30727e0
-sirene,NA,5b7ffc618b4c4169d30727e0
-entreprise,NA,5b7ffc618b4c4169d30727e0
-entreprises,NA,5b7ffc618b4c4169d30727e0
-siret,NA,5b7ffc618b4c4169d30727e0
 système national d'identification et du répertoire des entreprises et de leurs établissements,NA,5b7ffc618b4c4169d30727e0
 base SIRENE,NA,5b7ffc618b4c4169d30727e0
 SIRENE,NA,5b7ffc618b4c4169d30727e0
 Système informatisé du répertoire national des entreprises et des établissements,NA,5b7ffc618b4c4169d30727e0
 Musée d'art et d'histoire de Saint-Brieuc - historique des expositions,NA,5bae279c8b4c410765b5eb4e
-prénoms,NA,5bf42c958b4c4144b0110ce8
 Fichier des prénoms,NA,5bf42c958b4c4144b0110ce8
-élus,NA,5c34c4d1634f4173183a64f1
-RNE,NA,5c34c4d1634f4173183a64f1
-répertoire des élus,NA,5c34c4d1634f4173183a64f1
-repertoire des elus,NA,5c34c4d1634f4173183a64f1
 Répertoire national des élus,NA,5c34c4d1634f4173183a64f1
+RNE,NA,5c34c4d1634f4173183a64f1
 Demande de valeurs foncières,NA,5c4ae55a634f4117716d5656
 base DVF,NA,5c4ae55a634f4117716d5656
 DVF,NA,5c4ae55a634f4117716d5656
-grand débat,NA,5c5c3236634f4155110aa4ea
 fichier des personnes décédées,NA,5de8f397634f4164071119c5
 Fichier des décès,NA,5de8f397634f4164071119c5
 FPD,NA,5de8f397634f4164071119c5
@@ -118,5 +75,3 @@ matchID - Fichier des décès,NA,5de8f397634f4164071119c5
 Base nationale sur l'intercommunalité,NA,5e1f20058b4c414d3f94460d
 BANATIC,NA,5e1f20058b4c414d3f94460d
 Agribalyse,NA,5f71f6b9f23df7fcd508af57
-ovq,NA,5ff5e6e99724cb8fff59a5be
-baromètre des résultats,NA,5ff5e6e99724cb8fff59a5be


### PR DESCRIPTION
…//github.com/etalab/datagouv-search-indicator/issues/21

I'm not sure of the best strategy : erase the original datasets‧csv or keep two differnt files : one with wikidata and one without.

We go from 49 lines to 121 !

Here is the code which has been used to concatenates files. 
```
library(tidyverse)
read_csv("data/datasets‧csv") %>% 
  bind_rows(., read_csv("data/wikidata_labels‧csv")) %>%
  bind_rows(., read_csv("data/wikidata_alias‧csv")) %>%
  distinct() %>%
  arrange(expected) %>%
  write_csv("data/datasets_wikidata‧csv")

```