### PR TITLE
Add query dataset extracted using matomo

### DIFF
--- a/data/datasets_stats.csv
+++ b/data/datasets_stats.csv
@@ -1,182 +1,186 @@
-query,params,expected
 deces,,5de8f397634f4164071119c5
 décès,,5de8f397634f4164071119c5
 Décès,,5de8f397634f4164071119c5
-Fichier des personnes décédées,,5de8f397634f4164071119c5
 Deces,,5de8f397634f4164071119c5
 covid,,5de8f397634f4164071119c5
 DECES,,5de8f397634f4164071119c5
-fichiers des personnes decedees,,5de8f397634f4164071119c5
-insee,,5de8f397634f4164071119c5
-dvf,,5c4ae55a634f4117716d5656
-immobilier,,5c4ae55a634f4117716d5656
-foncier,,5c4ae55a634f4117716d5656
-valeurs foncieres,,5c4ae55a634f4117716d5656
-covid,,6010206e7aa742eb447930f7
-vaccination,,6010206e7aa742eb447930f7
-Vaccination,,6010206e7aa742eb447930f7
-vaccination covid,,6010206e7aa742eb447930f7
-Covid,,6010206e7aa742eb447930f7
+naissance,,5de8f397634f4164071119c5
 covid,,5e7e104ace2080d9162b61d8
-covid-19,,5e7e104ace2080d9162b61d8
 Covid,,5e7e104ace2080d9162b61d8
 covid hospitalisations,,5e7e104ace2080d9162b61d8
-siren,,5b7ffc618b4c4169d30727e0
+hospitalisation covid,,5e7e104ace2080d9162b61d8
+covid tests,,5e7e104ace2080d9162b61d8
+covid 19,,5e7e104ace2080d9162b61d8
+hospitalisation,,5e7e104ace2080d9162b61d8
+immobilier,,5c4ae55a634f4117716d5656
+dvf,,5c4ae55a634f4117716d5656
+DVF,,5c4ae55a634f4117716d5656
+valeurs foncieres,,5c4ae55a634f4117716d5656
+demande de valeur foncière,,5c4ae55a634f4117716d5656
+vaccination,,6010206e7aa742eb447930f7
+covid,,6010206e7aa742eb447930f7
+vaccination covid,,6010206e7aa742eb447930f7
+Vaccination,,6010206e7aa742eb447930f7
 sirene,,5b7ffc618b4c4169d30727e0
 siret,,5b7ffc618b4c4169d30727e0
+siren,,5b7ffc618b4c4169d30727e0
 entreprise,,5b7ffc618b4c4169d30727e0
 entreprises,,5b7ffc618b4c4169d30727e0
 SIRET,,5b7ffc618b4c4169d30727e0
-insee,,5b7ffc618b4c4169d30727e0
 SIREN,,5b7ffc618b4c4169d30727e0
 Sirene,,5b7ffc618b4c4169d30727e0
+SIRENE,,5b7ffc618b4c4169d30727e0
+situation au repertoire siren,,5b7ffc618b4c4169d30727e0
+covid,,60007bfb10632c47538583d8
+vaccination,,60007bfb10632c47538583d8
+taux d'incidence,,5ed1175ca00bbe1e4941a46a
 rna,,58e53811c751df03df38f42d
 RNA,,58e53811c751df03df38f42d
 association,,58e53811c751df03df38f42d
-associations,,58e53811c751df03df38f42d
 Association,,58e53811c751df03df38f42d
+associations,,58e53811c751df03df38f42d
 Rna,,58e53811c751df03df38f42d
 ASSOCIATION,,58e53811c751df03df38f42d
 Associations,,58e53811c751df03df38f42d
 numero rna,,58e53811c751df03df38f42d
-association loi 1901,,58e53811c751df03df38f42d
 numéro RNA,,58e53811c751df03df38f42d
-répertoire national des associations,,58e53811c751df03df38f42d
+association loi 1901,,58e53811c751df03df38f42d
+ASSOCIATIONS,,58e53811c751df03df38f42d
+repertoire national des associations,,58e53811c751df03df38f42d
+RNA association,,58e53811c751df03df38f42d
 organisme de formation,,582c8978c751df788ec0bb7e
-formation,,582c8978c751df788ec0bb7e
 organismes de formation,,582c8978c751df788ec0bb7e
-incidence covid,,5ed1175ca00bbe1e4941a46a
-calendrier scolaire,,5889d03ea3a72974cbf0d5b0
-Calendrier scolaire,,5889d03ea3a72974cbf0d5b0
-iCal,,5889d03ea3a72974cbf0d5b0
-Vacances scolaires,,5889d03ea3a72974cbf0d5b0
-vacances scolaires,,5889d03ea3a72974cbf0d5b0
-covid,,60007bfb10632c47538583d8
-GID,,60007bfb10632c47538583d8
-marseille,,5cebfa8306e3e77ffdb31ef5
+formation,,582c8978c751df788ec0bb7e
+liste des organismes de formation,,582c8978c751df788ec0bb7e
 covid,,60190d00a7273a8100dd4d38
+covid-19,,60190d00a7273a8100dd4d38
 covid,,5ed117db6c161bd5baf070be
 covid tests,,5ed117db6c161bd5baf070be
-sidep,,5ed117db6c161bd5baf070be
+calendrier scolaire,,5889d03ea3a72974cbf0d5b0
+calendrier,,5889d03ea3a72974cbf0d5b0
+Calendrier scolaire,,5889d03ea3a72974cbf0d5b0
+vacances scolaires,,5889d03ea3a72974cbf0d5b0
 zrr,,5943d13588ee38742a95eb0c
 permis de construire,,5a5f4f6c88ee387da4d252a3
 sitadel,,5a5f4f6c88ee387da4d252a3
-codes postaux,,545b55e1c751df52de9b6045
+construire,,5a5f4f6c88ee387da4d252a3
 code postal,,545b55e1c751df52de9b6045
 code postaux,,545b55e1c751df52de9b6045
+codes postaux,,545b55e1c751df52de9b6045
+la base des codes postaux,,545b55e1c751df52de9b6045
 csv,,545b55e1c751df52de9b6045
-Codes Postaux,,545b55e1c751df52de9b6045
+le base des codes postaux,,545b55e1c751df52de9b6045
+communes,,53699233a3a729239d203e69
+commune,,53699233a3a729239d203e69
+contour commune,,53699233a3a729239d203e69
+limites communales,,53699233a3a729239d203e69
+communes france,,53699233a3a729239d203e69
+découpage communal,,53699233a3a729239d203e69
 dvf,,5cc1b94a634f4165e96436c1
 DVF,,5cc1b94a634f4165e96436c1
 prix terrain,,5cc1b94a634f4165e96436c1
 Prix terrain,,5cc1b94a634f4165e96436c1
-etalab,,5cc1b94a634f4165e96436c1
 valeurs foncières,,5cc1b94a634f4165e96436c1
-communes,,53699233a3a729239d203e69
-limites communales,,53699233a3a729239d203e69
-commune,,53699233a3a729239d203e69
-contour commune,,53699233a3a729239d203e69
-découpage communal,,53699233a3a729239d203e69
-Communes,,53699233a3a729239d203e69
-geofla departement 2015,,53699233a3a729239d203e69
-marseille,,53699233a3a729239d203e69
 cadastre,,59b0020ec751df07d5f13bcf
 Cadastre,,59b0020ec751df07d5f13bcf
 CADASTRE,,59b0020ec751df07d5f13bcf
-entreprise rge,,600966dac71dd5e4f7bcbf5c
 ROME,,58da857388ee384902e505f5
-rome,,58da857388ee384902e505f5
-accident,,53698f4ca3a729239d2036df
-accidents,,53698f4ca3a729239d2036df
-sécurité routière,,53698f4ca3a729239d2036df
-baac,,53698f4ca3a729239d2036df
-département,,5726ef67c751df48e1fcca0d
-consommation énergie,,5726ef67c751df48e1fcca0d
-cadastre,,58e5924b88ee3802ca255566
-covid,,5f69ecb155c43420918410b8
+lovac,,61816c6e23197bb34835228e
+Lovac,,61816c6e23197bb34835228e
 adresse,,5530fbacc751df5ff937dddb
 adresses,,5530fbacc751df5ff937dddb
-ban,,5530fbacc751df5ff937dddb
-RPG,,58d8d8a0c751df17537c66be
+Adresse,,5530fbacc751df5ff937dddb
+cadastre,,58e5924b88ee3802ca255566
+dxf,,58e5924b88ee3802ca255566
+Plan cadastral,,58e5924b88ee3802ca255566
+accident,,53698f4ca3a729239d2036df
+accidents,,53698f4ca3a729239d2036df
+accidents corporels,,53698f4ca3a729239d2036df
 rpg,,58d8d8a0c751df17537c66be
-population,,53699d0ea3a729239d205b2e
-recensement,,53699d0ea3a729239d205b2e
-Ciqual,,5369a15fa3a729239d2065b7
-ciqual,,5369a15fa3a729239d2065b7
-Table ciqual,,5369a15fa3a729239d2065b7
-table ciqual,,5369a15fa3a729239d2065b7
+RPG,,58d8d8a0c751df17537c66be
+agriculture,,58d8d8a0c751df17537c66be
+pac,,58d8d8a0c751df17537c66be
 Arcep,,58c98b1888ee38770950152b
 arcep,,58c98b1888ee38770950152b
-pole emploi,,561fa564c751df4f2acdbb48
+ciqual,,5369a15fa3a729239d2065b7
+Ciqual,,5369a15fa3a729239d2065b7
+Table ciqual,,5369a15fa3a729239d2065b7
+population,,53699d0ea3a729239d205b2e
+recensement,,53699d0ea3a729239d205b2e
+pvd,,5fc1259b703620ed60a49d97
+villes,,5fc1259b703620ed60a49d97
 finess,,53699569a3a729239d2046eb
 extraction finess,,53699569a3a729239d2046eb
 Extraction FINESS,,53699569a3a729239d2046eb
-Extraction finess,,53699569a3a729239d2046eb
 FINESS,,53699569a3a729239d2046eb
-Finess,,53699569a3a729239d2046eb
-Guadeloupe,,53699569a3a729239d2046eb
-EXTRACTION FINESS,,53699569a3a729239d2046eb
+Extraction finess,,53699569a3a729239d2046eb
 extraction FINESS,,53699569a3a729239d2046eb
-guadeloupe,,53699569a3a729239d2046eb
-pvd,,5fc1259b703620ed60a49d97
-Mariage,,5c9a52458b4c4175d54c24c8
-maire,,5c34c4d1634f4173183a64f1
+EXTRACTION FINESS,,53699569a3a729239d2046eb
+Finess,,53699569a3a729239d2046eb
 rne,,5c34c4d1634f4173183a64f1
+RNE,,5c34c4d1634f4173183a64f1
+maire,,5c34c4d1634f4173183a64f1
 maires,,5c34c4d1634f4173183a64f1
-Prix terrain,,54cb4f89c751df0c24467389
+accidents,,53698f4ca3a729239d2036df
+accident,,53698f4ca3a729239d2036df
 corine land cover,,5863714388ee3863df3f4e5d
-icpe,,5d8da992634f414b1c98117b
+covid,,5f69ecb155c43420918410b8
+coronavirus,,5f69ecb155c43420918410b8
+ehpad,,5f69ecb155c43420918410b8
+Prix terrain,,54cb4f89c751df0c24467389
 ICPE,,5d8da992634f414b1c98117b
+icpe,,5d8da992634f414b1c98117b
 seveso,,5d8da992634f414b1c98117b
 fantoir,,53699580a3a729239d204738
-département loire atlantique,,536991b0a3a729239d203d13
-Quels sont les partenaires du dispositif e-Pass Jeunes de la Région Sud,,5ce8864e9ce2e749b70dbf2b
-Naissance,,5c9a50b48b4c417241056daf
-jours fériés,,5b3cc551c751df4822526c1c
-police,,5369986ba3a729239d204f55
-mairies,,53699fe4a3a729239d206227
-mairie,,53699fe4a3a729239d206227
-json,,53699fe4a3a729239d206227
+FANTOIR,,53699580a3a729239d204738
+département,,536991b0a3a729239d203d13
+prenom,,5bf42c958b4c4144b0110ce8
+prénoms France,,5bf42c958b4c4144b0110ce8
+prénom,,5bf42c958b4c4144b0110ce8
+prénoms,,5bf42c958b4c4144b0110ce8
+prénom france,,5bf42c958b4c4144b0110ce8
+prenoms,,5bf42c958b4c4144b0110ce8
+Fichier des prénoms de 1900 à 2019,,5bf42c958b4c4144b0110ce8
+prénoms france,,5bf42c958b4c4144b0110ce8
+prenoms france,,5bf42c958b4c4144b0110ce8
+prenom france,,5bf42c958b4c4144b0110ce8
+prénom France,,5bf42c958b4c4144b0110ce8
+prénom Angers,,5bf42c958b4c4144b0110ce8
+Prénom,,5bf42c958b4c4144b0110ce8
+prenom de 1900,,5bf42c958b4c4144b0110ce8
+Prénoms,,5bf42c958b4c4144b0110ce8
+prénoms de 1900,,5bf42c958b4c4144b0110ce8
 arcep,,547d8d7ac751df405d090fcb
 fibre,,547d8d7ac751df405d090fcb
-region,,536991b2a3a729239d203d1a
+mairie,,53699fe4a3a729239d206227
+mairies,,53699fe4a3a729239d206227
+annuaire,,53699fe4a3a729239d206227
+Fichier consolidé des Bornes de Recharge pour Véhicules Electriques (IRVE),,5448d3e0c751df01f85d0572
+Fichier consolidé des Bornes de Recharge pour Véhicules Electriques,,5448d3e0c751df01f85d0572
+Fichier consolidé des Bornes de Recharge pour Véhicules Électriques,,5448d3e0c751df01f85d0572
+fichier consolidé des bornes de recharge pour véhicules électriques,,5448d3e0c751df01f85d0572
+irve consolidation,,5448d3e0c751df01f85d0572
+irve,,5448d3e0c751df01f85d0572
 régions,,536991b2a3a729239d203d1a
-région,,536991b2a3a729239d203d1a
+region,,536991b2a3a729239d203d1a
 regions,,536991b2a3a729239d203d1a
-prenom,,5bf42c958b4c4144b0110ce8
-prénom,,5bf42c958b4c4144b0110ce8
-prénoms France,,5bf42c958b4c4144b0110ce8
-prénoms,,5bf42c958b4c4144b0110ce8
-prenoms,,5bf42c958b4c4144b0110ce8
-prénoms france,,5bf42c958b4c4144b0110ce8
-prénom France,,5bf42c958b4c4144b0110ce8
+dpo,,5c926a7a634f410578005c68
+prénom,,586a824588ee3835ec3f4e61
+prenom,,586a824588ee3835ec3f4e61
+prénoms,,586a824588ee3835ec3f4e61
+prenoms,,586a824588ee3835ec3f4e61
+prenom 1900,,586a824588ee3835ec3f4e61
+prénoms de 1900,,586a824588ee3835ec3f4e61
 véhicule co2,,53ba4c07a3a729219b7bead3
 vehicule co2,,53ba4c07a3a729219b7bead3
 véhicule CO2,,53ba4c07a3a729219b7bead3
-co2,,53ba4c07a3a729219b7bead3
-véhicule,,53ba4c07a3a729219b7bead3
 véhicules co2,,53ba4c07a3a729219b7bead3
-pollution,,53ba4c07a3a729219b7bead3
-CO2,,53ba4c07a3a729219b7bead3
-vehicule,,53ba4c07a3a729219b7bead3
 vehicule CO2,,53ba4c07a3a729219b7bead3
-véhicule Co2,,53ba4c07a3a729219b7bead3
-Fichier consolidé des Bornes de Recharge pour Véhicules Électriques,,5448d3e0c751df01f85d0572
-Fichier consolidé des Bornes de Recharge pour Véhicules Electriques [IRVE],,5448d3e0c751df01f85d0572
-IRVE,,5448d3e0c751df01f85d0572
-irve,,5448d3e0c751df01f85d0572
-irve consolidation,,5448d3e0c751df01f85d0572
-fichier,,5448d3e0c751df01f85d0572
-Fichier consolidé des Bornes de Recharge pour Véhicules Electriques,,5448d3e0c751df01f85d0572
-Fichier consolidé des Bornes de Recharge pour Véhicules Électriques”,,5448d3e0c751df01f85d0572
-Opérations coordonnées par les CROSS,,5b320fa7c751df1d7a4febae
-cross,,5b320fa7c751df1d7a4febae
-CROSS,,5b320fa7c751df1d7a4febae
-opérations coordonnées par les CROSS,,5b320fa7c751df1d7a4febae
-operation cross,,5b320fa7c751df1d7a4febae
-monuments historiques,,536c47bfa3a72933d8d1b3a6
-dpo,,5c926a7a634f410578005c68
-carburant,,54101458a3a72937cb2c703c
-carburants,,54101458a3a72937cb2c703c
-prix carburants,,54101458a3a72937cb2c703c
+car labelling,,53ba4c07a3a729219b7bead3
+pollution,,53ba4c07a3a729219b7bead3
+véhicule,,53ba4c07a3a729219b7bead3
 temps de parole des hommes et des femmes à la télévision et à la radio,,5c6adbae634f4114a5c41776
+temps de parole,,5c6adbae634f4114a5c41776
+temps de parole des femmes,,5c6adbae634f4114a5c41776
+temps de paroles,,5c6adbae634f4114a5c41776
+revenu,,536998cba3a729239d20505e

--- a/data/datasets_stats.csv
+++ b/data/datasets_stats.csv
@@ -1,0 +1,182 @@
+query,params,expected
+deces,,5de8f397634f4164071119c5
+décès,,5de8f397634f4164071119c5
+Décès,,5de8f397634f4164071119c5
+Fichier des personnes décédées,,5de8f397634f4164071119c5
+Deces,,5de8f397634f4164071119c5
+covid,,5de8f397634f4164071119c5
+DECES,,5de8f397634f4164071119c5
+fichiers des personnes decedees,,5de8f397634f4164071119c5
+insee,,5de8f397634f4164071119c5
+dvf,,5c4ae55a634f4117716d5656
+immobilier,,5c4ae55a634f4117716d5656
+foncier,,5c4ae55a634f4117716d5656
+valeurs foncieres,,5c4ae55a634f4117716d5656
+covid,,6010206e7aa742eb447930f7
+vaccination,,6010206e7aa742eb447930f7
+Vaccination,,6010206e7aa742eb447930f7
+vaccination covid,,6010206e7aa742eb447930f7
+Covid,,6010206e7aa742eb447930f7
+covid,,5e7e104ace2080d9162b61d8
+covid-19,,5e7e104ace2080d9162b61d8
+Covid,,5e7e104ace2080d9162b61d8
+covid hospitalisations,,5e7e104ace2080d9162b61d8
+siren,,5b7ffc618b4c4169d30727e0
+sirene,,5b7ffc618b4c4169d30727e0
+siret,,5b7ffc618b4c4169d30727e0
+entreprise,,5b7ffc618b4c4169d30727e0
+entreprises,,5b7ffc618b4c4169d30727e0
+SIRET,,5b7ffc618b4c4169d30727e0
+insee,,5b7ffc618b4c4169d30727e0
+SIREN,,5b7ffc618b4c4169d30727e0
+Sirene,,5b7ffc618b4c4169d30727e0
+rna,,58e53811c751df03df38f42d
+RNA,,58e53811c751df03df38f42d
+association,,58e53811c751df03df38f42d
+associations,,58e53811c751df03df38f42d
+Association,,58e53811c751df03df38f42d
+Rna,,58e53811c751df03df38f42d
+ASSOCIATION,,58e53811c751df03df38f42d
+Associations,,58e53811c751df03df38f42d
+numero rna,,58e53811c751df03df38f42d
+association loi 1901,,58e53811c751df03df38f42d
+numéro RNA,,58e53811c751df03df38f42d
+répertoire national des associations,,58e53811c751df03df38f42d
+organisme de formation,,582c8978c751df788ec0bb7e
+formation,,582c8978c751df788ec0bb7e
+organismes de formation,,582c8978c751df788ec0bb7e
+incidence covid,,5ed1175ca00bbe1e4941a46a
+calendrier scolaire,,5889d03ea3a72974cbf0d5b0
+Calendrier scolaire,,5889d03ea3a72974cbf0d5b0
+iCal,,5889d03ea3a72974cbf0d5b0
+Vacances scolaires,,5889d03ea3a72974cbf0d5b0
+vacances scolaires,,5889d03ea3a72974cbf0d5b0
+covid,,60007bfb10632c47538583d8
+GID,,60007bfb10632c47538583d8
+marseille,,5cebfa8306e3e77ffdb31ef5
+covid,,60190d00a7273a8100dd4d38
+covid,,5ed117db6c161bd5baf070be
+covid tests,,5ed117db6c161bd5baf070be
+sidep,,5ed117db6c161bd5baf070be
+zrr,,5943d13588ee38742a95eb0c
+permis de construire,,5a5f4f6c88ee387da4d252a3
+sitadel,,5a5f4f6c88ee387da4d252a3
+codes postaux,,545b55e1c751df52de9b6045
+code postal,,545b55e1c751df52de9b6045
+code postaux,,545b55e1c751df52de9b6045
+csv,,545b55e1c751df52de9b6045
+Codes Postaux,,545b55e1c751df52de9b6045
+dvf,,5cc1b94a634f4165e96436c1
+DVF,,5cc1b94a634f4165e96436c1
+prix terrain,,5cc1b94a634f4165e96436c1
+Prix terrain,,5cc1b94a634f4165e96436c1
+etalab,,5cc1b94a634f4165e96436c1
+valeurs foncières,,5cc1b94a634f4165e96436c1
+communes,,53699233a3a729239d203e69
+limites communales,,53699233a3a729239d203e69
+commune,,53699233a3a729239d203e69
+contour commune,,53699233a3a729239d203e69
+découpage communal,,53699233a3a729239d203e69
+Communes,,53699233a3a729239d203e69
+geofla departement 2015,,53699233a3a729239d203e69
+marseille,,53699233a3a729239d203e69
+cadastre,,59b0020ec751df07d5f13bcf
+Cadastre,,59b0020ec751df07d5f13bcf
+CADASTRE,,59b0020ec751df07d5f13bcf
+entreprise rge,,600966dac71dd5e4f7bcbf5c
+ROME,,58da857388ee384902e505f5
+rome,,58da857388ee384902e505f5
+accident,,53698f4ca3a729239d2036df
+accidents,,53698f4ca3a729239d2036df
+sécurité routière,,53698f4ca3a729239d2036df
+baac,,53698f4ca3a729239d2036df
+département,,5726ef67c751df48e1fcca0d
+consommation énergie,,5726ef67c751df48e1fcca0d
+cadastre,,58e5924b88ee3802ca255566
+covid,,5f69ecb155c43420918410b8
+adresse,,5530fbacc751df5ff937dddb
+adresses,,5530fbacc751df5ff937dddb
+ban,,5530fbacc751df5ff937dddb
+RPG,,58d8d8a0c751df17537c66be
+rpg,,58d8d8a0c751df17537c66be
+population,,53699d0ea3a729239d205b2e
+recensement,,53699d0ea3a729239d205b2e
+Ciqual,,5369a15fa3a729239d2065b7
+ciqual,,5369a15fa3a729239d2065b7
+Table ciqual,,5369a15fa3a729239d2065b7
+table ciqual,,5369a15fa3a729239d2065b7
+Arcep,,58c98b1888ee38770950152b
+arcep,,58c98b1888ee38770950152b
+pole emploi,,561fa564c751df4f2acdbb48
+finess,,53699569a3a729239d2046eb
+extraction finess,,53699569a3a729239d2046eb
+Extraction FINESS,,53699569a3a729239d2046eb
+Extraction finess,,53699569a3a729239d2046eb
+FINESS,,53699569a3a729239d2046eb
+Finess,,53699569a3a729239d2046eb
+Guadeloupe,,53699569a3a729239d2046eb
+EXTRACTION FINESS,,53699569a3a729239d2046eb
+extraction FINESS,,53699569a3a729239d2046eb
+guadeloupe,,53699569a3a729239d2046eb
+pvd,,5fc1259b703620ed60a49d97
+Mariage,,5c9a52458b4c4175d54c24c8
+maire,,5c34c4d1634f4173183a64f1
+rne,,5c34c4d1634f4173183a64f1
+maires,,5c34c4d1634f4173183a64f1
+Prix terrain,,54cb4f89c751df0c24467389
+corine land cover,,5863714388ee3863df3f4e5d
+icpe,,5d8da992634f414b1c98117b
+ICPE,,5d8da992634f414b1c98117b
+seveso,,5d8da992634f414b1c98117b
+fantoir,,53699580a3a729239d204738
+département loire atlantique,,536991b0a3a729239d203d13
+Quels sont les partenaires du dispositif e-Pass Jeunes de la Région Sud,,5ce8864e9ce2e749b70dbf2b
+Naissance,,5c9a50b48b4c417241056daf
+jours fériés,,5b3cc551c751df4822526c1c
+police,,5369986ba3a729239d204f55
+mairies,,53699fe4a3a729239d206227
+mairie,,53699fe4a3a729239d206227
+json,,53699fe4a3a729239d206227
+arcep,,547d8d7ac751df405d090fcb
+fibre,,547d8d7ac751df405d090fcb
+region,,536991b2a3a729239d203d1a
+régions,,536991b2a3a729239d203d1a
+région,,536991b2a3a729239d203d1a
+regions,,536991b2a3a729239d203d1a
+prenom,,5bf42c958b4c4144b0110ce8
+prénom,,5bf42c958b4c4144b0110ce8
+prénoms France,,5bf42c958b4c4144b0110ce8
+prénoms,,5bf42c958b4c4144b0110ce8
+prenoms,,5bf42c958b4c4144b0110ce8
+prénoms france,,5bf42c958b4c4144b0110ce8
+prénom France,,5bf42c958b4c4144b0110ce8
+véhicule co2,,53ba4c07a3a729219b7bead3
+vehicule co2,,53ba4c07a3a729219b7bead3
+véhicule CO2,,53ba4c07a3a729219b7bead3
+co2,,53ba4c07a3a729219b7bead3
+véhicule,,53ba4c07a3a729219b7bead3
+véhicules co2,,53ba4c07a3a729219b7bead3
+pollution,,53ba4c07a3a729219b7bead3
+CO2,,53ba4c07a3a729219b7bead3
+vehicule,,53ba4c07a3a729219b7bead3
+vehicule CO2,,53ba4c07a3a729219b7bead3
+véhicule Co2,,53ba4c07a3a729219b7bead3
+Fichier consolidé des Bornes de Recharge pour Véhicules Électriques,,5448d3e0c751df01f85d0572
+Fichier consolidé des Bornes de Recharge pour Véhicules Electriques [IRVE],,5448d3e0c751df01f85d0572
+IRVE,,5448d3e0c751df01f85d0572
+irve,,5448d3e0c751df01f85d0572
+irve consolidation,,5448d3e0c751df01f85d0572
+fichier,,5448d3e0c751df01f85d0572
+Fichier consolidé des Bornes de Recharge pour Véhicules Electriques,,5448d3e0c751df01f85d0572
+Fichier consolidé des Bornes de Recharge pour Véhicules Électriques”,,5448d3e0c751df01f85d0572
+Opérations coordonnées par les CROSS,,5b320fa7c751df1d7a4febae
+cross,,5b320fa7c751df1d7a4febae
+CROSS,,5b320fa7c751df1d7a4febae
+opérations coordonnées par les CROSS,,5b320fa7c751df1d7a4febae
+operation cross,,5b320fa7c751df1d7a4febae
+monuments historiques,,536c47bfa3a72933d8d1b3a6
+dpo,,5c926a7a634f410578005c68
+carburant,,54101458a3a72937cb2c703c
+carburants,,54101458a3a72937cb2c703c
+prix carburants,,54101458a3a72937cb2c703c
+temps de parole des hommes et des femmes à la télévision et à la radio,,5c6adbae634f4114a5c41776

--- a/scripts/matomo_query_datasets.py
+++ b/scripts/matomo_query_datasets.py
@@ -1,0 +1,107 @@
+import argparse
+import csv
+import requests
+import tqdm
+
+MIN_REFERRALS = 4
+DEFAULT_DOMAIN = 'www.data.gouv.fr'
+DEFAULT_STATS_DOMAIN = 'stats.data.gouv.fr'
+DEFAULT_SITE_ID = 109
+
+
+class MatomoQueryDatasetBuilder:
+
+    base_param = {
+        'module': 'API',
+        'format': 'json',
+        'token_auth': 'anonymous',
+        'period': 'range',
+        'date': 'previous30',
+    }
+
+    def __init__(self, stats_domain, dataset_domain, site_id, scheme, dataset_path):
+        self.stats_domain = stats_domain
+        self.dataset_domain = dataset_domain
+        self.base_param['idSite'] = site_id
+        self.scheme = scheme
+        self.base_url = f'{self.scheme}://{self.stats_domain}/index.php'
+        self.dataset_path = dataset_path
+
+    def get_pages_following_site_searches(self):
+        '''Get the most popular fr/datasets pages that follow a site search'''
+        r = requests.get(self.base_url, params={**self.base_param,
+                                                'method': 'Actions.getPageUrlsFollowingSiteSearch',
+                                                'expanded': 1,
+                                                'filter_limit': 10})
+
+        r.raise_for_status()
+        pages = r.json()
+        pages = next(elem for elem in pages if elem['label'] == 'fr')['subtable']
+        pages = next(elem for elem in pages if elem['label'] == 'datasets')['subtable']
+        pages = [elem['label'] for elem in pages if elem['label'] not in ['/index', '/?q=', 'Others']]
+        return pages
+
+    def get_page_id(self, page):
+        '''Get page id from the page name'''
+        r = requests.get(f'{self.scheme}://{self.dataset_domain}/api/1/datasets/' + page + '/')
+        r.raise_for_status()
+        return r.json()['id']
+
+
+    def get_page_searches(self, page):
+        '''Get searches that led to the page with a number of referrals >= MIN_REFERRALS'''
+        r = requests.get(self.base_url, params={**self.base_param,
+                                                'method': 'Transitions.getTransitionsForPageUrl',
+                                                'pageUrl': f'https://{self.dataset_domain}/fr/datasets/' + page + '/',
+                                                'filter_limit': 50,
+                                                'limitBeforeGrouping': 50,
+                                                })
+        r.raise_for_status()    
+        queries = r.json()['previousSiteSearches'][:-1]
+        queries = [elem['label'] for elem in queries if elem['referrals'] >= MIN_REFERRALS]
+        return queries
+
+
+    def save_query_dataset(self, page_query_dict, page_ids):
+        '''Save the queries with their associated pages'''
+        with open(f'data/{self.dataset_path}', 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            for page in page_query_dict:
+                writer.writerows([(query, None, page_ids[page]) for query in page_query_dict[page]])
+
+
+    def create_query_dataset(self):
+        '''Create a test dataset with queries and their expected datasets based on matomo search logs'''
+        pages = self.get_pages_following_site_searches()
+
+        page_ids = {page: self.get_page_id(page) for page in pages}
+
+        page_query_dict = {}
+        for page in tqdm.tqdm(pages):
+            queries = self.get_page_searches(page)
+            page_query_dict[page] = queries
+
+        self.save_query_dataset(page_query_dict, page_ids)
+
+        count_queries = sum([len(page_query_dict[page]) for page in page_query_dict])
+        return count_queries
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--stats-domain', dest="stats_domain", default=DEFAULT_STATS_DOMAIN)
+    parser.add_argument('--dataset-domain', dest="dataset_domain", default=DEFAULT_DOMAIN)
+    parser.add_argument('--site-id', dest="site_id", type=int, default=DEFAULT_SITE_ID)
+    parser.add_argument('--scheme', dest="scheme", default='https')
+    parser.add_argument('--output-dataset-path', dest="output_dataset_path", default='data/datasets_stats.csv')
+    args = parser.parse_args()
+
+    print('Running dataset builder on {0}', args.stats_domain)
+    print('This operation may take a long time')
+    dataset_builder = MatomoQueryDatasetBuilder(args.stats_domain, args.dataset_domain, args.site_id, args.scheme, args.output_dataset_path)
+    try:
+        count_queries = dataset_builder.create_query_dataset()
+        print(f'Created {args.output_dataset_path} with {count_queries} queries based on {args.stats_domain}')
+    except Exception as e:
+        print("Error: Failed to build query dataset from matomo stats. Error: " + str(e))


### PR DESCRIPTION
Add a query dataset `datasets_stats.csv` with 181 `(query, dataset)` tuples generated using Matomo stats.

We followed the pattern discussed [here](https://github.com/etalab/datagouv-search-indicator/pull/22) and add this generated dataset in a separated file.

The generation logic is the following:
- We get the most common dataset pages that follow site searches 
- Then we get the most common queries that led to these pages
- We associate the queries with the targeted dataset if the query->dataset count more than 4 times

The code used to generate this dataset can be cleaned and submitted here or in a separate PR if needed: https://github.com/maudetes/datagouv-search-indicator/blob/add-matomo-query-dataset/scripts/matomo_query_datasets.py.